### PR TITLE
ci: add manual trigger for deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,7 @@
 name: Deploy to Cloud Run
 
 on:
+  workflow_dispatch:  # Allow manual trigger
   workflow_run:
     workflows: ["Release"]
     types:


### PR DESCRIPTION
Adds workflow_dispatch to enable manual deployment runs from GitHub Actions UI.