### PR TITLE
fix: allow deploy workflow to run on manual trigger

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,8 +16,8 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
-    # Only run if Release workflow succeeded
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    # Run on manual trigger OR if Release workflow succeeded
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     permissions:
       contents: 'read'
       id-token: 'write'


### PR DESCRIPTION
Updates the job condition to run on workflow_dispatch events in addition to successful Release workflow runs.