### PR TITLE
fix: use RELEASE_TOKEN for semantic-release to bypass branch protection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,5 +32,5 @@ jobs:
       - name: Run semantic-release
         id: semantic
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: semantic-release version --changelog


### PR DESCRIPTION
## Problem
The Release workflow fails because \GITHUB_TOKEN\ cannot push directly to main due to branch protection rules.

## Solution
Use a custom \RELEASE_TOKEN\ (PAT) with bypass permissions instead of \GITHUB_TOKEN\.

## Required Action
Add the \RELEASE_TOKEN\ secret to the repository before merging.