### PR TITLE
ci: add workflow_dispatch trigger to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: Release
 
 on:
+  workflow_dispatch:  # Allow manual trigger
   push:
     branches:
       - main


### PR DESCRIPTION
Allows manual triggering of the release workflow for re-runs.