### PR TITLE
chore: authenticate release workflow with GitHub App

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,18 @@ jobs:
       version: ${{ steps.semantic.outputs.version }}
 
     steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -33,5 +42,5 @@ jobs:
       - name: Run semantic-release
         id: semantic
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: semantic-release version --changelog


### PR DESCRIPTION
Updates the release workflow to use a GitHub App for authentication. This allows semantic-release to bypass branch protection rulesets.