### PR TITLE
fix: bump memory to 512Mi and tune concurrency for lxml workload

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,10 +62,10 @@ jobs:
             BGG_API_KEY=${{ secrets.BGG_API_KEY }}
           flags: |
             --cpu=1
-            --memory=256Mi
+            --memory=512Mi
             --min-instances=0
             --max-instances=3
-            --concurrency=80
+            --concurrency=40
             --timeout=30s
             --cpu-boost
             --allow-unauthenticated

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,5 +14,6 @@ RUN uv sync --frozen --no-dev
 # Copy application code
 COPY *.py ./
 
-# Run the bot
-CMD ["uv", "run", "main.py"]
+# Run the bot directly via the venv's python (avoids keeping uv resident)
+ENV PATH="/app/.venv/bin:$PATH"
+CMD ["python", "main.py"]


### PR DESCRIPTION
## Summary
- Bump Cloud Run memory from 256Mi to 512Mi — baseline (PTB + tornado + lxml) sits around 270MB, causing OOM at container startup.
- Lower `--concurrency` from 80 to 40: each in-flight BGG response holds a parsed lxml tree (~2-5× raw XML size), so capping concurrency bounds peak transient memory without hurting I/O-bound throughput.
- Run `python main.py` directly in the container (via the venv `PATH`) instead of `uv run main.py` — avoids keeping `uv` resident (~20-30MB).

Free-tier math still holds: 512Mi × typical runtime stays well within the 360,000 GB-s/month allocation.

## Test plan
- [ ] Deploy to Cloud Run via `workflow_dispatch` on this branch
- [ ] Confirm the revision reaches ready state (no port-timeout failure)
- [ ] Verify bot responds to an inline query in Telegram
- [ ] Check Cloud Monitoring `container/memory/utilizations` — should sit comfortably below the 512Mi ceiling