### PR TITLE
fix: drop bot token from webhook URL path

### DIFF
--- a/main.py
+++ b/main.py
@@ -45,13 +45,14 @@ def main() -> None:
         port = int(os.getenv("PORT", "8080"))
         webhook_secret = os.getenv("WEBHOOK_SECRET")
         if not webhook_secret:
-            logger.warning("WEBHOOK_SECRET not set - webhook requests will not be verified!")
+            logger.error("WEBHOOK_SECRET is required when running in webhook mode")
+            return
         logger.info(f"Starting webhook on port {port}...")
         application.run_webhook(
             listen="0.0.0.0",
             port=port,
-            url_path=token,
-            webhook_url=f"{webhook_url}/{token}",
+            url_path="telegram",
+            webhook_url=f"{webhook_url}/telegram",
             secret_token=webhook_secret,
         )
     else:


### PR DESCRIPTION
## Summary
- Remove the bot token from the webhook URL path — it was being logged by Cloud Run's default HTTP request logs (`httpRequest.requestUrl`) on every Telegram webhook delivery, letting anyone with `roles/logging.viewer` retrieve the token without needing Secret Manager access.
- Switch `url_path` to a fixed opaque value (`"telegram"`). `secret_token` (header-based, not logged) remains the real auth mechanism.
- Fail closed if `WEBHOOK_SECRET` is unset: with the token no longer acting as a path-based secret, `secret_token` is the only auth, so the previous warn-and-continue was a silent-insecure fallback.

## Why it was this way
The `url_path=token` pattern predates Telegram's `X-Telegram-Bot-Api-Secret-Token` header (Feb 2022) and was the historically recommended way to verify webhook authenticity. With `secret_token` now in use, the path provides no security value and only exposes the credential.

## Deployment impact
python-telegram-bot calls `setWebhook` on startup, so the new URL is registered with Telegram automatically on next restart. Zero downtime beyond the restart itself.

## Test plan
- [ ] Deploy and confirm Cloud Run logs show `httpRequest.requestUrl` ending in `/telegram`, not the bot token
- [ ] Send a test message to the bot and confirm it responds (webhook handler still receives updates)
- [ ] Confirm deploy fails fast if `WEBHOOK_SECRET` binding is missing from Cloud Run