### PR TITLE
ci: detect release via tag at HEAD

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       group: release-${{ github.ref }}
       cancel-in-progress: false
     outputs:
-      released: ${{ steps.semantic.outputs.released }}
+      released: ${{ steps.detect.outputs.released }}
       version: ${{ steps.semantic.outputs.version }}
 
     steps:
@@ -47,6 +47,15 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: semantic-release version --changelog
+
+      - name: Detect release
+        id: detect
+        run: |
+          if git tag --points-at HEAD | grep -q '^v[0-9]'; then
+            echo "released=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "released=false" >> "$GITHUB_OUTPUT"
+          fi
 
   deploy:
     needs: release


### PR DESCRIPTION
## Summary
- The `released` output from python-semantic-release CLI was not propagating reliably as `'true'`, causing the deploy job to be skipped on legitimate releases.
- Replace the output source with a step that checks for a `v*` tag pointing at HEAD after semantic-release runs.
- The release-bot's commit becomes the local HEAD and is tagged, so this is an unambiguous signal of "a release happened".
- Trigger logic and `[skip ci]` protection are unchanged.

## Test plan
- [ ] Merge a `fix:`/`feat:`/`perf:` PR and confirm the deploy job runs against the new tag
- [ ] Merge a `ci:` or `chore:` PR and confirm the deploy job is skipped