### PR TITLE
chore: identify BGG API client via User-Agent

### DIFF
--- a/bgg_client.py
+++ b/bgg_client.py
@@ -10,7 +10,11 @@ load_dotenv()
 
 
 class BGGClient:
+    # BGG XML API2 — terms of use: https://boardgamegeek.com/xmlapi/termsofuse
     BASE_URL = "https://boardgamegeek.com/xmlapi2"
+    USER_AGENT = (
+        "BoardGameSearchTelegramBot (+https://github.com/JCaet/boardgame-search-telegram-bot)"
+    )
     API_KEY = os.getenv("BGG_API_KEY")
 
     # Connection pooling: Shared client instance
@@ -31,7 +35,7 @@ class BGGClient:
 
     @staticmethod
     def _get_headers() -> dict[str, str]:
-        headers: dict[str, str] = {}
+        headers: dict[str, str] = {"User-Agent": BGGClient.USER_AGENT}
         if BGGClient.API_KEY:
             headers["Authorization"] = f"Bearer {BGGClient.API_KEY}"
         return headers

--- a/uv.lock
+++ b/uv.lock
@@ -17,7 +17,7 @@ wheels = [
 
 [[package]]
 name = "boardgame-search-telegram-bot"
-version = "1.2.0"
+version = "1.3.1"
 source = { virtual = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

The BGG client was sending no `User-Agent`, so requests went out as `python-httpx`'s default anonymous UA. BGG community guidance asks API consumers to self-identify (with a contact URL) so any abuse can be traced back to the project rather than the library. Switch to a named UA and add a comment pointing at BGG's [terms of use](https://boardgamegeek.com/xmlapi/termsofuse).

Caught during a broader BGG compliance audit of the sister bot `game-night-decider` — the sister repo was using a *spoofed Chrome* UA, which is worse than anonymous; both are now identifying.

`uv.lock`: resync against the pyproject version bump already on main.

## Test plan
- [ ] Search works end-to-end (inline query, direct message)
- [ ] Request inspection confirms `User-Agent: BoardGameSearchTelegramBot (...)`