### PR TITLE
chore: switch GitHub App auth from app-id to client-id

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.GH_APP_ID }}
+          client-id: ${{ secrets.GH_APP_CLIENT_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

`actions/create-github-app-token` deprecated the `app-id` input in favor of `client-id` — every Release run has been logging `Input 'app-id' has been deprecated with message: Use 'client-id' instead.` Switch to the new input.

New secret `GH_APP_CLIENT_ID` (already added) holds the **Client ID** from the GitHub App settings page. `GH_APP_ID` is safe to delete once one release run on `main` succeeds.

No action version bump — `@v3` already supports `client-id`.

## Test plan
- [ ] Merge and confirm the next Release run no longer emits the deprecation warning
- [ ] Release run completes successfully (semantic-release still authenticates)