### PR TITLE
chore: tighten CI/CD permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
 
@@ -27,6 +29,8 @@ jobs:
 
   type-check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
 
@@ -44,6 +48,8 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         python-version: ["3.11", "3.12", "3.13", "3.14"]

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,6 +48,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref || github.sha }}
+          persist-credentials: false
 
       - name: Google Auth
         id: auth


### PR DESCRIPTION
## Summary

Low-risk, mechanical tightening from the recent CI/CD security review:

- **ci.yml** — explicit \`contents: read\` on every job. Lockdown of the default \`GITHUB_TOKEN\` scope; belt-and-suspenders for fork-PR safety if secrets are ever introduced to CI jobs later.
- **deploy.yml** — \`persist-credentials: false\` on checkout. The job never pushes, so the token being persisted in \`.git/config\` served no purpose.

## Not doing

- \`id-token: write\` on the release workflow stays. The caller's \`GITHUB_TOKEN\` permissions cap the reusable deploy workflow's permissions, so dropping it here would break WIF auth in the called deploy job.
- \`docker/login-action@v4\` and the ref-scoped release \`concurrency\` block are already correct on this repo; those items from the review apply to the sister repo.

## Test plan
- [ ] CI checks still pass on this PR
- [ ] After merge, next Release run succeeds and the triggered Deploy run still authenticates to GCP