### PR TITLE
chore: CI hardening round 2 — SHA pins, smoke test, cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
 on:
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
 
@@ -13,7 +15,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
 
       - name: Set up Python
         run: uv python install 3.12
@@ -35,7 +37,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
 
       - name: Set up Python
         run: uv python install 3.12
@@ -57,7 +59,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
 
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
@@ -69,7 +71,7 @@ jobs:
         run: uv run pytest --cov --cov-report=xml
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
         with:
           files: ./coverage.xml
           fail_ci_if_error: false

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,14 +59,14 @@ jobs:
           token_format: 'access_token'
 
       - name: Docker Login to Artifact Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           registry: us-central1-docker.pkg.dev
           username: oauth2accesstoken
           password: ${{ steps.auth.outputs.access_token }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
 
       - name: Build and Push Container
         run: |
@@ -85,8 +85,15 @@ jobs:
           sync_secret() {
             local name="$1"
             local value="$2"
+            local prev
+            prev=$(gcloud secrets versions list "$name" --project="$PROJECT_ID" \
+              --filter="state=ENABLED" --format="value(name)" --sort-by="~createTime")
             printf '%s' "$value" | gcloud secrets versions add "$name" \
               --project="$PROJECT_ID" --data-file=-
+            for v in $prev; do
+              gcloud secrets versions destroy "$v" --secret="$name" \
+                --project="$PROJECT_ID" --quiet || true
+            done
           }
           sync_secret bgg-bot-telegram-token "$TELEGRAM_BOT_TOKEN"
           sync_secret bgg-bot-bgg-api-key "$BGG_API_KEY"
@@ -99,7 +106,7 @@ jobs:
           region: ${{ env.REGION }}
           image: us-central1-docker.pkg.dev/${{ env.PROJECT_ID }}/cloud-run-source-deploy/${{ env.SERVICE_NAME }}:${{ inputs.ref || github.sha }}
           env_vars: |
-            WEBHOOK_URL=${{ secrets.WEBHOOK_URL }}
+            WEBHOOK_URL=${{ vars.WEBHOOK_URL }}
           secrets: |
             TELEGRAM_BOT_TOKEN=bgg-bot-telegram-token:latest
             BGG_API_KEY=bgg-bot-bgg-api-key:latest
@@ -113,6 +120,15 @@ jobs:
             --timeout=30s
             --cpu-boost
             --allow-unauthenticated
+
+      - name: Smoke test
+        run: |
+          status=$(curl -s -o /dev/null -w '%{http_code}' "${{ vars.WEBHOOK_URL }}/telegram")
+          echo "Webhook endpoint returned HTTP $status"
+          if [ "$status" -ge 500 ]; then
+            echo "::error::Smoke test failed — webhook endpoint returned $status"
+            exit 1
+          fi
 
       - name: Clean up old container images
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.12-slim@sha256:804ddf3251a60bbf9c92e73b7566c40428d54d0e79d3428194edf40da6521286
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary

Follow-up from the CI/CD security review (#51 covered round 1). This covers items 6–11:

- **SHA-pin third-party actions** — `astral-sh/setup-uv`, `codecov/codecov-action`, `docker/login-action` are now pinned to commit SHA with version comments so Dependabot still bumps them. First-party `actions/*` and `google-github-actions/*` stay on major tags.
- **CI on push to main** — catches post-merge regressions that slip through PR checks (e.g. semantic-release commits).
- **Destroy prior secret versions** — `sync_secret()` now destroys previously-enabled versions after adding the new one, keeping one active version per secret. Only runs during explicit `sync_secrets=true` rotation — normal deploys skip this step entirely.
- **Post-deploy smoke test** — curls `$WEBHOOK_URL/telegram` and fails the workflow on 5xx.
- **WEBHOOK_URL → vars** — it's the Cloud Run service URL (not sensitive). Moved from `secrets` to `vars` for clarity. **Action needed:** add `WEBHOOK_URL` as a repository variable (Settings → Secrets and variables → Actions → Variables tab), then delete the old secret.
- **Dockerfile digest pin** — `python:3.12-slim` pinned by SHA256 digest for reproducible builds.

## Test plan
- [ ] CI runs on this PR (lint/type-check/test should pass — no code changes)
- [ ] After merge: create `WEBHOOK_URL` repo variable, delete old secret, trigger a deploy with `sync_secrets=true` to verify secret rotation + smoke test + image cleanup